### PR TITLE
Allow for a context passed in then reviving a process

### DIFF
--- a/lib/Schedule/LongSteps.pm
+++ b/lib/Schedule/LongSteps.pm
@@ -354,18 +354,20 @@ and will be used to load the process, a blank context is used if not provided.
 =head2 revive
 
 Revive a longstep process to a given step within a Longstep process.
-If no method is given then the process will revive on the failed process step.
+
+A context is required when the reviving process contains required attributes
+and when setting a step to reviving step. If no step is given then the process
+will revive on the failed process step, when setting a step that doesn't
+require a context, use an empty hashref '{}'.
+
 If you need to modify the state before reviving the longstep process, it is
 recommended to have a revive step ("revive_do_broken_step") which modifies
 the state as needed and returns a next_step to continue the process.
-In the process of reviving a process, the process has to be built which may
-require a context to be passed if no context is passed in, then an empty
-context is used.
 
 This method will confess on any issues.
 
     eval {
-        $self->revive( $pid , $method_to_revive_to, $context );
+        $self->revive( $pid, $context, $method_to_revive_to );
     };
 
 =head1 SEE ALSO
@@ -494,7 +496,7 @@ sub load_process {
 }
 
 sub revive {
-    my ( $self, $process_id, $revive_to, $context ) = @_;
+    my ( $self, $process_id, $context, $revive_to  ) = @_;
     $context ||= {};
 
     my $stored_process = $self->find_process($process_id);

--- a/lib/Schedule/LongSteps.pm
+++ b/lib/Schedule/LongSteps.pm
@@ -358,11 +358,14 @@ If no method is given then the process will revive on the failed process step.
 If you need to modify the state before reviving the longstep process, it is
 recommended to have a revive step ("revive_do_broken_step") which modifies
 the state as needed and returns a next_step to continue the process.
+In the process of reviving a process, the process has to be built which may
+require a context to be passed if no context is passed in, then an empty
+context is used.
 
 This method will confess on any issues.
 
     eval {
-        $self->revive( $pid , $method_to_revive_to );
+        $self->revive( $pid , $method_to_revive_to, $context );
     };
 
 =head1 SEE ALSO
@@ -491,7 +494,8 @@ sub load_process {
 }
 
 sub revive {
-    my ( $self, $process_id, $revive_to ) = @_;
+    my ( $self, $process_id, $revive_to, $context ) = @_;
+    $context ||= {};
 
     my $stored_process = $self->find_process($process_id);
     confess "There is no $process_id to revive" unless $stored_process;
@@ -502,7 +506,7 @@ sub revive {
     # if revive $revive_to was not passed, used the function we failed on.
     # and check that also, just in case we attempt to revive on a method
     # that was previously removed.
-    my $loaded_process = $self->_load_stored_process($stored_process);
+    my $loaded_process = $self->_load_stored_process($stored_process, $context);
 
     $revive_to = $stored_process->what() unless $revive_to;
 

--- a/t/revive.t
+++ b/t/revive.t
@@ -48,7 +48,7 @@ ok( $long_steps->run_due_processes() );
 like( $process->error(), qr(something went wrong), 'something did go wrong' );
 
 # this should die, as there is no do_the_hoff
-eval{ $long_steps->revive( $process->id(), 'do_the_hoff' ) };
+eval{ $long_steps->revive( $process->id(), {}, 'do_the_hoff' ) };
 like( $@, qr(Unable revive \d+ to do_the_hoff), 'revive to an incorrect function' );
 
 $do_break_stuff_fails = 0;

--- a/t/revive_with_context.t
+++ b/t/revive_with_context.t
@@ -1,0 +1,86 @@
+#! perl -wt
+
+use Test::More;
+use Schedule::LongSteps;
+
+my $do_break_stuff_fails = 1;
+{
+
+    package MyProcess;
+    use Moose;
+    extends qw/Schedule::LongSteps::Process/;
+
+    use DateTime;
+    has 'required_att' => ( is => 'ro', isa => 'Str', required => 1 );
+
+    sub build_first_step {
+        my ($self) = @_;
+        return $self->new_step(
+            { what => 'do_break_stuff', run_at => DateTime->now() } );
+    }
+
+    sub do_break_stuff {
+        my ($self) = @_;
+        die 'something went wrong' if $do_break_stuff_fails;
+        return $self->new_step(
+            { what => 'do_final_step', run_at => DateTime->now() } );
+    }
+
+    sub do_final_step {
+        my ($self) = @_;
+        return $self->final_step( { state => { the => 'final', state => 1 } } );
+    }
+}
+
+# this process requires some context
+my $required_context = { required_att => 'saussage' };
+
+ok( my $long_steps = Schedule::LongSteps->new() );
+
+ok(
+    my $process = $long_steps->instantiate_process(
+        'MyProcess', $required_context, { beef => 'saussage' }
+    )
+);
+ok( $process->id() );
+
+is( $process->what(), 'do_break_stuff' );
+is_deeply( $process->state(), { beef => 'saussage' } );
+
+# Time to run!
+ok( $long_steps->run_due_processes($required_context) );
+
+# do_break_stuff fails
+like( $process->error(), qr(something went wrong), 'something did go wrong' );
+
+$do_break_stuff_fails = 0;
+eval { $long_steps->revive( $process->id() ) };
+like(
+    $@,
+    qr|Attribute \(required_att\) is required at|,
+    'failed as the context was not provived'
+);
+
+# the process was not revived, so the error and state are stil the same
+like( $process->error(), qr(something went wrong), 'something is still wrong' );
+is( $process->status(), 'terminated', 'process status is terminated' );
+
+# now revive with a context
+ok( $long_steps->revive( $process->id(), $required_context ) );
+
+# the process was fullyrevived, so the error and state have been reset
+is( $process->error(),  undef,    'error has been reset' );
+is( $process->status(), 'paused', 'process status is paused' );
+
+ok( $long_steps->run_due_processes($required_context), 'run the revived step' );
+
+# And check the step properties have been
+ok( $long_steps->run_due_processes($required_context), 'run the final step' );
+is_deeply( $process->state(), { the => 'final', state => 1 } );
+is( $process->status(), 'terminated' );
+is( $process->run_at(), undef );
+
+# # # Check no due step have run again
+ok( !$long_steps->run_due_processes($required_context) );
+
+done_testing();

--- a/t/revive_with_revival_step.t
+++ b/t/revive_with_revival_step.t
@@ -75,14 +75,14 @@ is( $process->what(), 'do_break_stuff' );
 like( $process->error(), qr(something went wrong), 'something did go wrong' );
 
 # this should die, as there is no do_the_hoff
-eval{ $long_steps->revive( $process->id(), 'do_the_hoff' ) };
+eval{ $long_steps->revive( $process->id(), {}, 'do_the_hoff' ) };
 like( $@, qr(Unable revive \d+ to do_the_hoff), 'revive to an incorrect function' );
 
 is( $long_steps->revive( $process->id() ), 1, 'Process was revived, but will still fail' );
 ok( $long_steps->run_due_processes(), 'run the revival step' );
 like( $process->error(), qr(something went wrong), 'Although rivived this is still broken ' );
 
-is( $long_steps->revive( $process->id(), 'revive_do_break_stuff' ), 1, 'Process was revived with its revival step' );
+is( $long_steps->revive( $process->id(), {}, 'revive_do_break_stuff' ), 1, 'Process was revived with its revival step' );
 is( $process->error(),  undef,    'revived process error was undef' );
 is( $process->status(), "paused", 'revived process status is paused' );
 


### PR DESCRIPTION
So if the process you want to load has some required attributes and by not passing in the context things tend to go bang that is not good. :(

This PR allows for a context to be passed into the rivive method. This is option 1, option 2 is to remove the loading and checking (check the other PR)