### PR TITLE
Remove the method checking on revival.

### DIFF
--- a/lib/Schedule/LongSteps.pm
+++ b/lib/Schedule/LongSteps.pm
@@ -359,6 +359,9 @@ If you need to modify the state before reviving the longstep process, it is
 recommended to have a revive step ("revive_do_broken_step") which modifies
 the state as needed and returns a next_step to continue the process.
 
+NOTE, there is no method checking when reviving, and will fail
+when the process is next run.
+
 This method will confess on any issues.
 
     eval {
@@ -498,16 +501,8 @@ sub revive {
 
     confess("$process_id does not have a status of 'terminated'") if ( $stored_process->status() ne "terminated" );
 
-    # load the process and check if process have the method to revive_to
     # if revive $revive_to was not passed, used the function we failed on.
-    # and check that also, just in case we attempt to revive on a method
-    # that was previously removed.
-    my $loaded_process = $self->_load_stored_process($stored_process);
-
     $revive_to = $stored_process->what() unless $revive_to;
-
-    # check to see if we able to revive
-    confess "Unable revive $process_id to $revive_to" unless $loaded_process->can($revive_to);
 
     # Set the process up to be revived.
     $stored_process->what($revive_to);

--- a/t/revive.t
+++ b/t/revive.t
@@ -47,12 +47,13 @@ is_deeply( $process->state(), { beef => 'saussage' } );
 ok( $long_steps->run_due_processes() );
 like( $process->error(), qr(something went wrong), 'something did go wrong' );
 
-# this should die, as there is no do_the_hoff
-eval{ $long_steps->revive( $process->id(), 'do_the_hoff' ) };
-like( $@, qr(Unable revive \d+ to do_the_hoff), 'revive to an incorrect function' );
+# revive to a non existent method, do_the_hoff
+ok( $long_steps->revive( $process->id(), 'do_the_hoff' ) );
+ok( $long_steps->run_due_processes(), 'run the revival step' );
+like( $process->error(), qr(locate object method \"do_the_hoff"), 'revive to an incorrect function' );
 
 $do_break_stuff_fails = 0;
-is( $long_steps->revive( $process->id() ), 1, 'Process was revived' );
+is( $long_steps->revive( $process->id(), 'do_break_stuff' ), 1, 'Process was revived' );
 is( $process->error(),  undef,    'revived process error was undef' );
 is( $process->status(), "paused", 'revived process status is paused' );
 

--- a/t/revive_with_revival_step.t
+++ b/t/revive_with_revival_step.t
@@ -74,13 +74,15 @@ ok( $long_steps->run_due_processes(), 'run do_break_stuff' );
 is( $process->what(), 'do_break_stuff' );
 like( $process->error(), qr(something went wrong), 'something did go wrong' );
 
-# this should die, as there is no do_the_hoff
-eval{ $long_steps->revive( $process->id(), 'do_the_hoff' ) };
-like( $@, qr(Unable revive \d+ to do_the_hoff), 'revive to an incorrect function' );
-
+# revive as is and is still broken
 is( $long_steps->revive( $process->id() ), 1, 'Process was revived, but will still fail' );
 ok( $long_steps->run_due_processes(), 'run the revival step' );
 like( $process->error(), qr(something went wrong), 'Although rivived this is still broken ' );
+
+# revive to a non existent method, do_the_hoff
+ok( $long_steps->revive( $process->id(), 'do_the_hoff' ) );
+ok( $long_steps->run_due_processes(), 'run the revival step' );
+like( $process->error(), qr(locate object method \"do_the_hoff"), 'revive to an incorrect function' );
 
 is( $long_steps->revive( $process->id(), 'revive_do_break_stuff' ), 1, 'Process was revived with its revival step' );
 is( $process->error(),  undef,    'revived process error was undef' );


### PR DESCRIPTION
Remove the loading and revive method checking,  this means a process can be revived without the need to pass in a context.  

Package checking is out as well (see below)

```
$stored_process->process_class->can($revive_to)

```

As this does not work for non-simple processes, so it better to remove it all together.
