### PR TITLE
Retry on transaction deadlocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,12 +146,14 @@ Out of the box, the following storage classes are available:
 - [Schedule::LongSteps::Storage::AutoDBIx](https://metacpan.org/pod/Schedule::LongSteps::Storage::AutoDBIx)
 
     Persist processes in a relational DB (a $dbh from [DBI](https://metacpan.org/pod/DBI)). This is the easiest thing to use if you want to persist processes in a database, without having
-    to worry about creating a DBIx::Class model yourself.
+    to worry about creating a DBIx::Class model yourself. We recommend you give this storage its own dbh connection, segregated from the rest
+    of your application.
 
 - [Schedule::LongSteps::Storage::DBIxClass](https://metacpan.org/pod/Schedule::LongSteps::Storage::DBIxClass)
 
-    Persist processes in an existing [DBIx::Class](https://metacpan.org/pod/DBIx::Class) schema. Nice if you want to have only one instance of Schema in your application and if
-    don't mind writing your own resultset.
+    Persist processes in an existing [DBIx::Class](https://metacpan.org/pod/DBIx::Class) schema. Note that although this makes a reasonable attempts not to interfer
+    with your own transactions, we recommend that you build a instance of your schema with a dedicated and segregated [DBI](https://metacpan.org/pod/DBI) connection
+    just for this LongSteps purpose.
 
 - [Schedule::LongSteps::Storage::DynamoDB](https://metacpan.org/pod/Schedule::LongSteps::Storage::DynamoDB)
 

--- a/cpanfile
+++ b/cpanfile
@@ -1,4 +1,5 @@
 
+requires 'Action::Retry' , '>= 0.24';
 requires 'Data::UUID' , '>= 1.220';
 requires 'DateTime' , '>= 1.18';
 requires 'DateTime::Format::ISO8601', '>= 0.08';
@@ -9,3 +10,4 @@ requires 'Scope::Guard', '>= 0.21';
 
 test_requires 'Test::More';
 test_requires 'Test::MockDateTime';
+test_requires 'Test::MockModule';

--- a/lib/Schedule/LongSteps.pm
+++ b/lib/Schedule/LongSteps.pm
@@ -440,7 +440,7 @@ sub run_due_processes{
                 $err = substr( $err , 0 , $self->error_limit() );
             }
             $log->error("Error running process ".$stored_process->process_class().':'.$stored_process->id().' :'.$err);
-            $stored_process->update({
+            $self->storage()->update_process( $stored_process, {
                 status => 'terminated',
                 error => $err,
                 run_at => undef,
@@ -456,7 +456,7 @@ sub run_due_processes{
             next;
         }
 
-        $stored_process->update({
+        $self->storage()->update_process( $stored_process, {
             status => 'paused',
             run_at => undef,
             run_id => undef,
@@ -528,7 +528,7 @@ sub revive {
     $stored_process->error(undef);
     $stored_process->status("paused");
     $stored_process->run_at( $now );
-    $stored_process->update({
+    $self->storage()->update_process( $stored_process, {
         what => $revive_to,
         error => undef,
         status => "paused",

--- a/lib/Schedule/LongSteps.pm
+++ b/lib/Schedule/LongSteps.pm
@@ -153,12 +153,14 @@ Persist processes in memory. Not very useful, except for testing. This is the st
 =item L<Schedule::LongSteps::Storage::AutoDBIx>
 
 Persist processes in a relational DB (a $dbh from L<DBI>). This is the easiest thing to use if you want to persist processes in a database, without having
-to worry about creating a DBIx::Class model yourself.
+to worry about creating a DBIx::Class model yourself. We recommend you give this storage its own dbh connection, segregated from the rest
+of your application.
 
 =item L<Schedule::LongSteps::Storage::DBIxClass>
 
-Persist processes in an existing L<DBIx::Class> schema. Nice if you want to have only one instance of Schema in your application and if
-don't mind writing your own resultset.
+Persist processes in an existing L<DBIx::Class> schema. Note that although this makes a reasonable attempts not to interfer
+with your own transactions, we recommend that you build a instance of your schema with a dedicated and segregated L<DBI> connection
+just for this LongSteps purpose.
 
 =item L<Schedule::LongSteps::Storage::DynamoDB>
 

--- a/lib/Schedule/LongSteps/Storage.pm
+++ b/lib/Schedule/LongSteps/Storage.pm
@@ -64,4 +64,20 @@ sub find_process{
 }
 
 
+=head2 update_process
+
+Updates the given stored process (as returned by 'find_process')
+with the given properties.
+
+Usage:
+
+ $this->update_process( $process , { run_at => DateTime->now(), .. } );
+
+=cut
+
+sub update_process{
+    my ($self, $process, $properties) = @_;
+    $process->update( $properties );
+}
+
 __PACKAGE__->meta()->make_immutable();

--- a/lib/Schedule/LongSteps/Storage/DBIxClass.pm
+++ b/lib/Schedule/LongSteps/Storage/DBIxClass.pm
@@ -6,6 +6,7 @@ extends qw/Schedule::LongSteps::Storage/;
 use DateTime;
 use Log::Any qw/$log/;
 use Scope::Guard;
+use Action::Retry;
 
 has 'schema' => ( is => 'ro', isa => 'DBIx::Class::Schema', required => 1);
 has 'resultset_name' => ( is => 'ro', isa => 'Str', required => 1);
@@ -182,11 +183,16 @@ sub prepare_due_processes{
 
 See L<Schedule::LongSteps::Storage>
 
+This override adds retrying in case of deadlock detection.
+
 =cut
 
 sub create_process{
     my ($self, $process_properties) = @_;
-    return $self->_get_resultset()->create($process_properties);
+    return $self->_retry_transaction(
+        sub{
+            return $self->_get_resultset()->create($process_properties);
+        });
 }
 
 =head2 find_process
@@ -198,6 +204,46 @@ See L<Schedule::LongSteps::Storage>
 sub find_process{
     my ($self, $process_id) = @_;
     return $self->_get_resultset()->find({ id => $process_id });
+}
+
+=head2 update_process
+
+Overrides L<Schedule::LongSteps::Storage#update_process> to add
+some retrying in case of DB deadlock detection.
+
+=cut
+
+override 'update_process' => sub{
+    my ($self, $process, $properties) = @_;
+    return $self->_retry_transaction( sub{
+                                          $log->trace("Attempting to update process ".$process->id());
+                                          $process->update( $properties );
+                                      } );
+};
+
+sub _retry_transaction{
+    my ($self, $code) = @_;
+
+    my $retry = Action::Retry->new(
+        attempt_code => $code,
+        retry_if_code => sub{
+            my $exception = $_[0];
+            # The driver tells us to retry the transaction.
+            # For instance: https://dev.mysql.com/doc/refman/5.6/en/innodb-deadlocks-handling.html
+
+            # Note that if this is false, then the Action::Retry code
+            # will set $@ to the last error and return whatever the code has returned (most
+            # probably undef in this case.
+            # This is managed by the error testing after the call to 'run'
+            return !! ( ( $exception || '' )  =~ m/try restarting transaction/ );
+        },
+        strategy => 'Fibonacci',
+    );
+    my $ret = $retry->run();
+    if( my $err = $@ ){
+        confess($err);
+    }
+    return $ret;
 }
 
 __PACKAGE__->meta->make_immutable();


### PR DESCRIPTION
This protects the update and the creation of a process against deadlocks that can occur when a table is being updated often concurrently.

https://dev.mysql.com/doc/refman/5.6/en/innodb-deadlocks-handling.html

I quote:

"Always be prepared to re-issue a transaction if it fails due to deadlock. Deadlocks are not dangerous. Just try again."

Boooo!